### PR TITLE
fix bulktool metadata

### DIFF
--- a/build/metadata.ps1
+++ b/build/metadata.ps1
@@ -121,9 +121,6 @@ function Parse-EnvironmentMetadata ($Properties) {
 		}
 		$environmentMetadata += Get-UpdateSchemasMetadata $updateSchemas $context
 	}
-    else {
-        $environmentMetadata += Get-BulkToolMetadata '' $context
-    }
 
 	return $environmentMetadata
 }


### PR DESCRIPTION
Раньше при запуске data tests требовался bulktool.
В декабре 2015 года это зарефакторили и теперь bulktool не нужен, но в метаданных это осталось.

Вот сейчас это дало о себе знать, я подкорректировал метаданные, сейчас при билде data tests метаданные для bulktool не подтягиваются.

@rechkalov

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/2gis/nuclear-river/83)
<!-- Reviewable:end -->
