### PR TITLE
long service names

### DIFF
--- a/build/metadata.taskservice.psm1
+++ b/build/metadata.taskservice.psm1
@@ -99,13 +99,13 @@ function Get-ServiceNameMetadata ($Context) {
 		'CustomerIntelligence.Replication.Host' {
 			return @{
 				'ServiceName' = 'CustomerIntelligence.Replication.Host'
-				'ServiceDisplayName' = 'CustomerIntelligence Replication Host Service'
+				'ServiceDisplayName' = '2GIS NuClear River CustomerIntelligence Replication Host Service'
 			}
 		}
 		'ConvertUseCasesService' {
 			return @{
 				'ServiceName' = 'ConvertUseCases'
-				'ServiceDisplayName' = 'NuClear River Convert UseCases Service'
+				'ServiceDisplayName' = '2GIS NuClear River Convert UseCases Service'
 			}
 		}
 	}


### PR DESCRIPTION
Без префикса 2GIS очень сложно визуально искать сервис в оснастке windows и в папке Program Files.
Считаю, зря его убрали, предлагаю вернуть.

@rechkalov @denisivan0v

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/2gis/nuclear-river/89)
<!-- Reviewable:end -->
