### PR TITLE
quartz cannot work both with CI and VR context at same time

### DIFF
--- a/CustomerIntelligence/CustomerIntelligence.Replication.Host/App.config
+++ b/CustomerIntelligence/CustomerIntelligence.Replication.Host/App.config
@@ -8,12 +8,12 @@
 	<appSettings>
 		<add key="IntegrationApplicationName" value="ERM20.Search" />
 		<add key="TransportEntityPath" value="topic.performedoperations.production.russia.import" />
-		<add key="EntryPointName" value="River.Replication" />
+		<add key="EntryPointName" value="River.Replication.CustomerIntelligence" />
 		<add key="TargetEnvironmentName" value="Dev" />
 		<add key="MaxWorkingThreads" value="5" />
 		<add key="JobStoreType" value="RAM" />
     <add key="MisfireThreshold" value="00:00:05" />
-    <add key="SchedulerName" value="ReplicationService.Scheduler.Dev" />
+    <add key="SchedulerName" value="ReplicationService.CustomerIntelligence.Scheduler.Dev" />
     <add key="LogstashUri" value="http://logstash.prod.erm.2gis.ru:8194" />
     <add key="SqlCommandTimeout" value="180" /> <!-- in seconds -->
     <add key="ReplicationBatchSize" value="1000" />

--- a/Environments/Erm.Production.config
+++ b/Environments/Erm.Production.config
@@ -8,7 +8,7 @@
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="IntegrationApplicationName" value="ERM.{DBSuffix}.Search"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
-    <add key="SchedulerName" value="ReplicationService.Scheduler.{EnvType}.{Country}"
+    <add key="SchedulerName" value="ReplicationService.CustomerIntelligence.Scheduler.{EnvType}.{Country}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="TransportEntityPath" value="{DestTopic}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>

--- a/Environments/Erm.config
+++ b/Environments/Erm.config
@@ -8,7 +8,7 @@
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="IntegrationApplicationName" value="ERM.{DBSuffix}.Search"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
-    <add key="SchedulerName" value="ReplicationService.Scheduler.{EnvType}.{Country}"
+    <add key="SchedulerName" value="ReplicationService.CustomerIntelligence.Scheduler.{EnvType}.{Country}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="TransportEntityPath" value="{DestTopic}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>

--- a/Environments/Templates/Erm.Test.config
+++ b/Environments/Templates/Erm.Test.config
@@ -8,7 +8,7 @@
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="IntegrationApplicationName" value="ERM{EnvNum}.Search"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
-    <add key="SchedulerName" value="ReplicationService.Scheduler.{EnvType}.{EnvNum}"
+    <add key="SchedulerName" value="ReplicationService.CustomerIntelligence.Scheduler.{EnvType}.{EnvNum}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="TransportEntityPath" value="{DestTopic}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>


### PR DESCRIPTION
Если на среде одновременно развёрнуты CI и VR контексты, то тогда quartz начинает сносить крышу, так как SchedulerName общий, задачи для CI контекста пытаются запуститься на VR ноде и наоборот, возникает FileNotFoundException для missing dll, хотя все dll есть, просто запустилась задача от другой ноды.

В Kibana тоже чехарда, EntryPointName общий и непонятно кто репортит ошибку.

Поэтому я ввёл имя контекста в параметры SchedulerName и EntryPointName.

@rechkalov @denisivan0v

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/2gis/nuclear-river/90)
<!-- Reviewable:end -->
